### PR TITLE
Add support for CustomModelData in currency

### DIFF
--- a/src/main/java/org/gestern/gringotts/Configuration.java
+++ b/src/main/java/org/gestern/gringotts/Configuration.java
@@ -201,6 +201,15 @@ public enum Configuration {
                         }
                     }
 
+                    if (denomConf.contains("customModelData")) {
+                        int customModelData = denomConf.getInt("customModelData"); // returns 0 when path is unset
+                        ItemMeta meta = denomType.getItemMeta();
+                        if (meta != null) {
+                            meta.setCustomModelData(customModelData);
+                            denomType.setItemMeta(meta);
+                        }
+                    }
+
                     ItemMeta meta = denomType.getItemMeta();
 
                     String name = denomConf.getString("displayname");


### PR DESCRIPTION
Allow the use of a customModelData field in the denominations.

Add a customModelData field in the denominations list of config.yml
Only the items with specified material and CustomModelData will be counted as currency.
This allow for items with custom textures from resource packs.

Example in config.yml :
denominations:
  - material: emerald
    customModelData: 1
    value: 1
  - material: emerald_block
    customModelData:1
    value: 9
