### PR TITLE
Fix autocompletion error

### DIFF
--- a/src/main/java/org/gestern/gringotts/commands/GringottsAbstractExecutor.java
+++ b/src/main/java/org/gestern/gringotts/commands/GringottsAbstractExecutor.java
@@ -250,6 +250,6 @@ public abstract class GringottsAbstractExecutor implements TabExecutor {
     }
 
     public boolean startsWithIgnoreCase(String source, String target) {
-        return source.substring(0, target.length()).equalsIgnoreCase(target);
+        return source.toLowerCase().startsWith(target.toLowerCase());
     }
 }


### PR DESCRIPTION
When trying to type /money deposit, send or withdraw, you were spammed in chat and in-game because the autocompletion produced an error, this pull request addresses that.