### PR TITLE
Reduce lag caused by getOfflinePlayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,8 +142,8 @@ buildNumber.properties
 ### VisualStudioCode ###
 .vscode/*
 !.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
+.vscode/tasks.json
+.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
 

--- a/src/main/java/org/gestern/gringotts/accountholder/AccountHolderFactory.java
+++ b/src/main/java/org/gestern/gringotts/accountholder/AccountHolderFactory.java
@@ -1,14 +1,18 @@
 package org.gestern.gringotts.accountholder;
 
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.gestern.gringotts.event.VaultCreationEvent;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.*;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Manages creating various types of AccountHolder centrally.

--- a/src/main/java/org/gestern/gringotts/api/impl/GringottsEco.java
+++ b/src/main/java/org/gestern/gringotts/api/impl/GringottsEco.java
@@ -164,15 +164,17 @@ public class GringottsEco implements Eco {
 
             if (player == null) {
                 //noinspection deprecation
-                if (Bukkit.getOfflinePlayer(id).hasPlayedBefore()) {
+                OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(id);
+                if (offlinePlayer.hasPlayedBefore()) {
                     //noinspection deprecation
-                    player = Bukkit.getOfflinePlayer(id);
+                    player = offlinePlayer;
                 } else {
                     try {
                         UUID targetUuid = UUID.fromString(id);
+                        offlinePlayer = Bukkit.getOfflinePlayer(targetUuid);
 
-                        if (Bukkit.getOfflinePlayer(targetUuid).hasPlayedBefore()) {
-                            player = Bukkit.getOfflinePlayer(targetUuid);
+                        if (offlinePlayer.hasPlayedBefore()) {
+                            player = offlinePlayer;
                         }
                     } catch (IllegalArgumentException ignored) {
                     }

--- a/src/main/java/org/gestern/gringotts/api/impl/VaultConnector.java
+++ b/src/main/java/org/gestern/gringotts/api/impl/VaultConnector.java
@@ -65,18 +65,19 @@ public class VaultConnector implements Economy {
 
         if (player == null) {
             //noinspection deprecation
-            if (Bukkit.getOfflinePlayer(accountId).hasPlayedBefore()) {
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
+            if (offlinePlayer.hasPlayedBefore()) {
                 //noinspection deprecation
-                player = Bukkit.getOfflinePlayer(accountId);
+                player = offlinePlayer;
             } else {
                 try {
                     UUID targetUuid = UUID.fromString(accountId);
+                    offlinePlayer = Bukkit.getOfflinePlayer(targetUuid);
 
-                    if (Bukkit.getOfflinePlayer(targetUuid).hasPlayedBefore()) {
-                        player = Bukkit.getOfflinePlayer(targetUuid);
+                    if (offlinePlayer.hasPlayedBefore()) {
+                        player = offlinePlayer;
                     }
-                } catch (IllegalArgumentException ignored) {
-                }
+                } catch (IllegalArgumentException ignored) {}
             }
         }
 
@@ -98,18 +99,19 @@ public class VaultConnector implements Economy {
 
         if (player == null) {
             //noinspection deprecation
-            if (Bukkit.getOfflinePlayer(accountId).hasPlayedBefore()) {
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
+            if (offlinePlayer.hasPlayedBefore()) {
                 //noinspection deprecation
-                player = Bukkit.getOfflinePlayer(accountId);
+                player = offlinePlayer;
             } else {
                 try {
                     UUID targetUuid = UUID.fromString(accountId);
 
-                    if (Bukkit.getOfflinePlayer(targetUuid).hasPlayedBefore()) {
-                        player = Bukkit.getOfflinePlayer(targetUuid);
+                    offlinePlayer = Bukkit.getOfflinePlayer(targetUuid);
+                    if (offlinePlayer.hasPlayedBefore()) {
+                        player = offlinePlayer;
                     }
-                } catch (IllegalArgumentException ignored) {
-                }
+                } catch (IllegalArgumentException ignored) {}
             }
         }
 
@@ -131,18 +133,19 @@ public class VaultConnector implements Economy {
 
         if (player == null) {
             //noinspection deprecation
-            if (Bukkit.getOfflinePlayer(accountId).hasPlayedBefore()) {
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
+            if (offlinePlayer.hasPlayedBefore()) {
                 //noinspection deprecation
-                player = Bukkit.getOfflinePlayer(accountId);
+                player = offlinePlayer;
             } else {
                 try {
                     UUID targetUuid = UUID.fromString(accountId);
+                    offlinePlayer = Bukkit.getOfflinePlayer(targetUuid);
 
-                    if (Bukkit.getOfflinePlayer(targetUuid).hasPlayedBefore()) {
-                        player = Bukkit.getOfflinePlayer(targetUuid);
+                    if (offlinePlayer.hasPlayedBefore()) {
+                        player = offlinePlayer;
                     }
-                } catch (IllegalArgumentException ignored) {
-                }
+                } catch (IllegalArgumentException ignored) {}
             }
         }
 
@@ -164,18 +167,19 @@ public class VaultConnector implements Economy {
 
         if (player == null) {
             //noinspection deprecation
-            if (Bukkit.getOfflinePlayer(accountId).hasPlayedBefore()) {
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
+            if (offlinePlayer.hasPlayedBefore()) {
                 //noinspection deprecation
-                player = Bukkit.getOfflinePlayer(accountId);
+                player = offlinePlayer;
             } else {
                 try {
                     UUID targetUuid = UUID.fromString(accountId);
+                    offlinePlayer = Bukkit.getOfflinePlayer(targetUuid);
 
-                    if (Bukkit.getOfflinePlayer(targetUuid).hasPlayedBefore()) {
-                        player = Bukkit.getOfflinePlayer(targetUuid);
+                    if (offlinePlayer.hasPlayedBefore()) {
+                        player = offlinePlayer;
                     }
-                } catch (IllegalArgumentException ignored) {
-                }
+                } catch (IllegalArgumentException ignored) {}
             }
         }
 


### PR DESCRIPTION
As Bukkit.getOfflinePlayer(String name) is doing a blocking web call, it is very slow and results in server freezes when there are many players online and plugins like Towny try to perform transactions.
To reduce this impact I avoided calling Bukkit.getOfflinePlayer() multiple times in a row when the result can be stored.

To further address the problem, I would like to discuss with you what the use of accessing the balance of a player who never logged on is. And maybe suppress this feature or at least always return an empty balance without checking if the player exists.