### PR TITLE
Remove blocking web calls

### DIFF
--- a/src/main/java/org/gestern/gringotts/api/impl/GringottsEco.java
+++ b/src/main/java/org/gestern/gringotts/api/impl/GringottsEco.java
@@ -1,5 +1,10 @@
 package org.gestern.gringotts.api.impl;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
@@ -11,13 +16,15 @@ import org.gestern.gringotts.GringottsAccount;
 import org.gestern.gringotts.accountholder.AccountHolder;
 import org.gestern.gringotts.accountholder.AccountHolderFactory;
 import org.gestern.gringotts.accountholder.PlayerAccountHolder;
-import org.gestern.gringotts.api.*;
+import org.gestern.gringotts.api.Account;
+import org.gestern.gringotts.api.BankAccount;
+import org.gestern.gringotts.api.Currency;
+import org.gestern.gringotts.api.Eco;
+import org.gestern.gringotts.api.PlayerAccount;
+import org.gestern.gringotts.api.Transaction;
+import org.gestern.gringotts.api.TransactionResult;
 import org.gestern.gringotts.currency.GringottsCurrency;
 import org.gestern.gringotts.data.DAO;
-
-import java.util.Collections;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * The type Gringotts eco.
@@ -163,10 +170,8 @@ public class GringottsEco implements Eco {
             OfflinePlayer player = Bukkit.getPlayer(id);
 
             if (player == null) {
-                //noinspection deprecation
-                OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(id);
-                if (offlinePlayer.hasPlayedBefore()) {
-                    //noinspection deprecation
+                OfflinePlayer offlinePlayer = List.of(Bukkit.getOfflinePlayers()).stream().filter(p -> p.getName().equals(id)).findAny().orElse(null);
+                if (offlinePlayer != null) {
                     player = offlinePlayer;
                 } else {
                     try {

--- a/src/main/java/org/gestern/gringotts/api/impl/VaultConnector.java
+++ b/src/main/java/org/gestern/gringotts/api/impl/VaultConnector.java
@@ -64,9 +64,8 @@ public class VaultConnector implements Economy {
         OfflinePlayer player = Bukkit.getPlayer(accountId);
 
         if (player == null) {
-            //noinspection deprecation
-            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
-            if (offlinePlayer.hasPlayedBefore()) {
+            OfflinePlayer offlinePlayer = List.of(Bukkit.getOfflinePlayers()).stream().filter(p -> p.getName().equals(accountId)).findAny().orElse(null);
+            if (offlinePlayer != null) {
                 //noinspection deprecation
                 player = offlinePlayer;
             } else {
@@ -98,9 +97,8 @@ public class VaultConnector implements Economy {
         OfflinePlayer player = Bukkit.getPlayer(accountId);
 
         if (player == null) {
-            //noinspection deprecation
-            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
-            if (offlinePlayer.hasPlayedBefore()) {
+            OfflinePlayer offlinePlayer = List.of(Bukkit.getOfflinePlayers()).stream().filter(p -> p.getName().equals(accountId)).findAny().orElse(null);
+            if (offlinePlayer != null) {
                 //noinspection deprecation
                 player = offlinePlayer;
             } else {
@@ -132,10 +130,8 @@ public class VaultConnector implements Economy {
         OfflinePlayer player = Bukkit.getPlayer(accountId);
 
         if (player == null) {
-            //noinspection deprecation
-            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
-            if (offlinePlayer.hasPlayedBefore()) {
-                //noinspection deprecation
+            OfflinePlayer offlinePlayer = List.of(Bukkit.getOfflinePlayers()).stream().filter(p -> p.getName().equals(accountId)).findAny().orElse(null);
+            if (offlinePlayer != null) {
                 player = offlinePlayer;
             } else {
                 try {
@@ -166,10 +162,8 @@ public class VaultConnector implements Economy {
         OfflinePlayer player = Bukkit.getPlayer(accountId);
 
         if (player == null) {
-            //noinspection deprecation
-            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(accountId);
-            if (offlinePlayer.hasPlayedBefore()) {
-                //noinspection deprecation
+            OfflinePlayer offlinePlayer = List.of(Bukkit.getOfflinePlayers()).stream().filter(p -> p.getName().equals(accountId)).findAny().orElse(null);
+            if (offlinePlayer != null) {
                 player = offlinePlayer;
             } else {
                 try {

--- a/src/main/java/org/gestern/gringotts/commands/GringottsAbstractExecutor.java
+++ b/src/main/java/org/gestern/gringotts/commands/GringottsAbstractExecutor.java
@@ -89,10 +89,8 @@ public abstract class GringottsAbstractExecutor implements TabExecutor {
         OfflinePlayer recipientPlayer = Bukkit.getPlayer(recipientName);
 
         if (recipientPlayer == null) {
-            //noinspection deprecation
-            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(recipientName);
-            if (offlinePlayer.hasPlayedBefore()) {
-                //noinspection deprecation
+            OfflinePlayer offlinePlayer = List.of(Bukkit.getOfflinePlayers()).stream().filter(p -> p.getName().equals(recipientName)).findAny().orElse(null);
+            if (offlinePlayer != null) {
                 recipientPlayer = offlinePlayer;
             } else {
                 try {


### PR DESCRIPTION
This PR hopefully fixes #121, I removed every instance of `Bukkit.getOfflinePlayer(String name)` and replaced them by checking if the player logged on at least once.

I tested with online players, offline players (without vault), town vaults, and nation vaults.
I think it is safer that you test this PR too as I may not be aware of all the side effects of my modification.