### PR TITLE
Allow using full ItemMeta for denominations

### DIFF
--- a/src/main/java/org/gestern/gringotts/AccountInventory.java
+++ b/src/main/java/org/gestern/gringotts/AccountInventory.java
@@ -49,10 +49,10 @@ public class AccountInventory {
 
         // try denominations from largest to smallest
         for (Denomination denomination : Configuration.CONF.getCurrency().getDenominations()) {
-            if (denomination.getValue() <= remaining) {
+            if (denomination.getValue() <= remaining && denomination.getValue() > 0) {
                 ItemStack stack = new ItemStack(denomination.getKey().type);
                 int stackSize = stack.getMaxStackSize();
-                long denItemCount = denomination.getValue() > 0 ? remaining / denomination.getValue() : 0;
+                long denItemCount = remaining / denomination.getValue();
 
                 // add stacks in this denomination until stuff is returned
                 while (denItemCount > 0) {

--- a/src/main/java/org/gestern/gringotts/Configuration.java
+++ b/src/main/java/org/gestern/gringotts/Configuration.java
@@ -194,16 +194,20 @@ public enum Configuration {
 
                     ItemStack denomType = itemByName(materialName);
 
+                    // Allow loading a serialized meta block and overriding it with the other fields
+                    ItemMeta meta = denomConf.getSerializable("meta", ItemMeta.class);
+                    // Default to the item's default meta if the one in the config doesn't exist
+                    if (meta == null) {
+                        meta = denomType.getItemMeta();
+                    }
+
                     if (denomConf.contains("damage")) {
                         short damage = (short) denomConf.getInt("damage"); // returns 0 when path is unset
-                        ItemMeta meta = denomType.getItemMeta();
                         if (meta != null) {
                             ((Damageable) meta).setDamage(damage);
                             denomType.setItemMeta(meta);
                         }
                     }
-
-                    ItemMeta meta = denomType.getItemMeta();
 
                     if (meta == null) {
                         continue;

--- a/src/main/java/org/gestern/gringotts/Language.java
+++ b/src/main/java/org/gestern/gringotts/Language.java
@@ -24,6 +24,14 @@ public enum Language {
     public String inv_balance;
     public String invalid_account;
     public String reload;
+    public String added_denomination;
+
+    // Adding a denomination
+    public String hold_item;
+    public String missing_value;
+    public String invalid_value;
+    public String denomination_name;
+    public String denomination_value;
     //pay command
     public String pay_success_tax;
     public String pay_success_sender;
@@ -87,6 +95,26 @@ public enum Language {
         LANG.reload = translator.apply(
                 "reload",
                 "Gringotts: Reloaded configuration!");
+        LANG.hold_item = translator.apply(
+                "added_denomination",
+                "Added denomination %name");
+        LANG.hold_item = translator.apply(
+                "errors.holdItem",
+                "Please hold an item");
+
+        LANG.missing_value = translator.apply(
+                "errors.missingValue",
+                "Missing argument: denomination value");
+
+        LANG.invalid_value = translator.apply(
+                "errors.invalidValue",
+                "Invalid argument '%value' is not a valid number for denomination value");
+        LANG.denomination_name = translator.apply(
+                "errors.denominationName",
+                "Invalid argument '%value' is not a valid number for denomination value");
+        LANG.denomination_value = translator.apply(
+                "errors.denominationValue",
+                "Invalid argument '%value' is not a valid number for denomination value");
 
         //pay command
         LANG.pay_success_sender = translator.apply(
@@ -168,6 +196,7 @@ public enum Language {
         LANG.plugin_faction_notInFaction = translator.apply(
                 "plugins.faction.notInFaction",
                 "Cannot create faction vault: You are not in a faction.");
+
 
         //worldguard plugin
         LANG.plugin_worldguard_noVaultPerm = translator.apply(

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -17,6 +17,14 @@ vault_balance: "Vault balance: %balance"
 inv_balance: "Inventory balance: %balance"
 invalidaccount: "Invalid account: %player"
 reload: "Gringotts: Reloaded configuration!"
+added_denomination: "Added denomination %name"
+
+errors:
+    denominationValue: "denomination value"
+    denominationName: "denomination name"
+    holdItem: "Please hold an item"
+    missingValue: "Missing argument: %name"
+    invalidValue: "Invalid argument '%value' is not a valid number for %name"
 
 pay:
     success:


### PR DESCRIPTION
Allow adding full ItemMeta to denominations in the config, and adds a helpful command to put them there (`/gringotts addden 1 Coin Coins`).

Closes #115. 
Closes #135. 
Closes #137. 
Closes #138.