### PR TITLE
Fix typo about vault not being found

### DIFF
--- a/src/main/java/org/gestern/gringotts/Gringotts.java
+++ b/src/main/java/org/gestern/gringotts/Gringotts.java
@@ -122,7 +122,7 @@ public class Gringotts extends JavaPlugin {
                 Bukkit.getPluginManager().disablePlugin(this);
 
                 getLogger().warning(
-                        "Vault was found. Other plugins may not be able to access Gringotts accounts."
+                        "Vault was not found. Other plugins may not be able to access Gringotts accounts."
                 );
 
                 return;


### PR DESCRIPTION
Spotted this in an email earlier today, thought I'd push the fix.