### PR TITLE
[Pull Request] Small addon to the gringott's config

### DIFF
--- a/src/main/java/org/gestern/gringotts/Configuration.java
+++ b/src/main/java/org/gestern/gringotts/Configuration.java
@@ -42,6 +42,13 @@ public enum Configuration {
     public boolean dropOverflowingItem = false;
 
     /**
+     *
+     * Check only CustomModelData for compatibility with different plugins.
+     *
+     */
+    public boolean custommodeldataOnly = false;
+
+    /**
      * Flat tax on every player-to-player transaction. This is a value in currency units.
      */
     public double transactionTaxFlat = 0;
@@ -157,6 +164,8 @@ public enum Configuration {
         parseCurrency(denomSection, savedConfig);
 
         CONF.dropOverflowingItem = savedConfig.getBoolean("drop-overflowing-item", false);
+
+        CONF.custommodeldataOnly = savedConfig.getBoolean("custommodeldata-only", false);
 
         CONF.transactionTaxFlat = savedConfig.getDouble("transactiontax.flat", 0);
         CONF.transactionTaxRate = savedConfig.getDouble("transactiontax.rate", 0);

--- a/src/main/java/org/gestern/gringotts/currency/DenominationKey.java
+++ b/src/main/java/org/gestern/gringotts/currency/DenominationKey.java
@@ -1,6 +1,11 @@
 package org.gestern.gringotts.currency;
 
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.gestern.gringotts.Configuration;
+
+import java.util.HashMap;
+import java.util.Objects;
 
 /**
  * Hashable information to identify a denomination by it's ItemStack.
@@ -11,17 +16,32 @@ public class DenominationKey {
      * Item type of this denomination.
      */
     public final ItemStack type;
-
+    public final Material typeMaterial;
+    public final Boolean hasCustomModelData;
+    public final Integer typeCustomModelData;
 
     /**
      * Create a denomination key based on an item stack.
      *
-     * @param type item type of denomination
+     * @param type    item type of denominations, based on key-value relation creates the Material typeMaterial - Integer typeCustomModelData variables.
+     *
+     * @see #typeMaterial
+     * @see #hasCustomModelData
+     * @see #typeCustomModelData
+     *
      */
     public DenominationKey(ItemStack type) {
         this.type = new ItemStack(type);
+        this.typeMaterial = type.getType();
+        this.hasCustomModelData = Objects.requireNonNull(type.getItemMeta()).hasCustomModelData();
+        if (this.hasCustomModelData) this.typeCustomModelData = type.getItemMeta().getCustomModelData();
+        else {
+            this.typeCustomModelData = 0;
+            type.getItemMeta().setCustomModelData(typeCustomModelData);
+        }
         this.type.setAmount(0);
     }
+
 
     @Override
     public boolean equals(Object o) {
@@ -31,6 +51,33 @@ public class DenominationKey {
         DenominationKey that = (DenominationKey) o;
 
         return type.equals(that.type);
+
+    }
+
+    /**
+     * Checks if its typeMaterial - typeCustomModelData relation is equal with the key variables.
+     *
+     * @param o is the object to validate
+     * @param onlyRelation defines if to check Material and CustomModelData only. If false equals(Object) is being used.
+     *
+     * @see #equals(Object) 
+     * @see #type
+     * @see #typeMaterial
+     * @see #hasCustomModelData
+     * @see #typeCustomModelData
+     *
+     * @author iomatix
+     * 
+     */
+    public boolean equals(Object o, Boolean onlyRelation) {
+        if (onlyRelation) {
+            if (o == null || this.getClass() != o.getClass()) return false;
+
+            DenominationKey that = (DenominationKey) o;
+            if (that.typeMaterial.equals(this.typeMaterial) && that.typeCustomModelData.equals(this.typeCustomModelData)) return true;
+        }
+
+        return this.equals(o);
 
     }
 

--- a/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
+++ b/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
@@ -198,7 +198,8 @@ public class GringottsCurrency {
     private Denomination getDenominationOf(ItemStack stack) {
         if(Configuration.CONF.custommodeldataOnly) {
             for(Denomination d : getDenominations()){
-                if(d.getKey().equals(stack,true)) return d;
+
+                if(d.getKey().equals(stack,true)) return denoms.get(d);
             }
         }
         DenominationKey d = new DenominationKey(stack);

--- a/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
+++ b/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.meta.BlockStateMeta;
 import org.gestern.gringotts.Configuration;
 
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -196,13 +197,14 @@ public class GringottsCurrency {
      * @return denomination for the item stack, or null if there is no such denomination
      */
     private Denomination getDenominationOf(ItemStack stack) {
+        DenominationKey d = new DenominationKey(stack);
         if(Configuration.CONF.custommodeldataOnly) {
-            for(Denomination d : getDenominations()){
-
-                if(d.getKey().equals(stack,true)) return denoms.get(d);
+            for(Denomination dthis : getDenominations()){
+                if(dthis.getKey().equals(d,true)) {
+                    return dthis;
+                }
             }
         }
-        DenominationKey d = new DenominationKey(stack);
 
         return denoms.get(d);
     }

--- a/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
+++ b/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
@@ -114,7 +114,6 @@ public class GringottsCurrency {
         }
 
         Denomination d = getDenominationOf(stack);
-
         return d != null ? d.getValue() * stack.getAmount() : 0;
     }
 
@@ -197,6 +196,11 @@ public class GringottsCurrency {
      * @return denomination for the item stack, or null if there is no such denomination
      */
     private Denomination getDenominationOf(ItemStack stack) {
+        if(Configuration.CONF.custommodeldataOnly) {
+            for(Denomination d : getDenominations()){
+                if(d.getKey().equals(stack,true)) return d;
+            }
+        }
         DenominationKey d = new DenominationKey(stack);
 
         return denoms.get(d);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,6 +47,9 @@ currency:
 #        - line1
 #        - line2
 
+# check only CustomModelData
+custommodeldata-only: false
+
 # tax on /money pay transactions
 transactiontax:
   flat: 0.0

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,7 +47,7 @@ currency:
 #        - line1
 #        - line2
 
-# check only CustomModelData
+# to check CustomModelData and Material data only during validation
 custommodeldata-only: false
 
 # tax on /money pay transactions


### PR DESCRIPTION
In the configuration files, a new option called `custommodeldata-only` has been added. By default, it is set to false. 
This option determines the type of currency checking used in the system.

## There are two types of currency checking available:
### Traditional Method:
If custommodeldata-only is set to false (the default), the system will use the traditional method for currency checking.
### Alternative Method using Material-CustomModelData Key-Value Pairs:
If custommodeldata-only is set to true, the system will use an alternative method for currency checking. 
In this approach, the system looks at the key-value pairs of material-custommodeldata to determine currency.

`This update provides flexibility in choosing the currency checking method based on your preferences or specific needs.`