### PR TITLE
Update paper maven repository url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
The old endpoint was retired and does not work anymore, causing builds without a local cache to fail. This updates the old endpoint to the new one.

This problem can be confirmed by deleting your maven cache (~/.m2 on Linux) and trying a clean rebuild, it will fail and it tries to download the dependencies from the paper repository.

I ran into this issue, so I thought I would help out by sharing the fix.