### PR TITLE
Fix ender chest withdrawal permission handling

### DIFF
--- a/src/main/java/org/gestern/gringotts/GringottsAccount.java
+++ b/src/main/java/org/gestern/gringotts/GringottsAccount.java
@@ -297,7 +297,9 @@ public class GringottsAccount {
                         remaining = removeFromShulkerBox(remaining, player.getInventory());
                     }
                 }
-                if (Configuration.CONF.useVaultEnderChest && remaining > 0) {
+                if (Configuration.CONF.useVaultEnderChest
+                        && Permissions.USE_VAULT_ENDERCHEST.isAllowed(player)
+                        && remaining > 0) {
                     remaining -= new AccountInventory(player.getEnderChest()).remove(remaining);
 
                     if (Configuration.CONF.includeShulkerBoxes && remaining > 0) {


### PR DESCRIPTION
## Summary
- honor the ender-chest vault permission when withdrawing currency
- keep withdrawal behavior consistent with balance and deposit paths

Closes #162

## Verification
- `mvn -B test -q`
- `mvn -B package -q`

A live Vault withdrawal with an ender-chest-only balance still needs a player session for final confirmation.