### PR TITLE
Report partial Vault deposits accurately

### DIFF
--- a/src/main/java/org/gestern/gringotts/api/impl/VaultConnector.java
+++ b/src/main/java/org/gestern/gringotts/api/impl/VaultConnector.java
@@ -127,14 +127,19 @@ public class VaultConnector implements Economy {
     }
 
     private EconomyResponse depositPlayer(Account account, double amount) {
+        double balanceBefore = account.balance();
         TransactionResult added = account.add(amount);
 
         switch (added) {
             case SUCCESS:
                 return new EconomyResponse(amount, account.balance(), ResponseType.SUCCESS, null);
-            case INSUFFICIENT_SPACE:
-                return new EconomyResponse(0, account.balance(), ResponseType.FAILURE, LANG
+            case INSUFFICIENT_SPACE: {
+                double balanceAfter = account.balance();
+                double deposited = Math.max(0, balanceAfter - balanceBefore);
+
+                return new EconomyResponse(deposited, balanceAfter, ResponseType.FAILURE, LANG
                         .plugin_vault_insufficientSpace);
+            }
             case ERROR:
             default:
                 return new EconomyResponse(0, account.balance(), ResponseType.FAILURE, LANG.plugin_vault_error);


### PR DESCRIPTION
## Summary
- report the actual deposited amount for partial `depositPlayer` operations
- retain `ResponseType.FAILURE` for `INSUFFICIENT_SPACE`
- return the post-deposit balance in the response

Closes #175

## Test plan
- [x] `mvn -B test -q`
- [x] `mvn -B package -q`
- [x] Manual/integration: zero, partial, and complete Vault deposits against a live provider