### PR TITLE
Add named player balance placeholders

### DIFF
--- a/src/main/java/org/gestern/gringotts/dependency/placeholdersapi/placeholders/PlaceholdersRegister.java
+++ b/src/main/java/org/gestern/gringotts/dependency/placeholdersapi/placeholders/PlaceholdersRegister.java
@@ -8,6 +8,9 @@ import org.gestern.gringotts.api.Account;
 import org.gestern.gringotts.api.impl.GringottsEco;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public class PlaceholdersRegister extends PlaceholderExpansion {
 
     private final GringottsEco eco;
@@ -33,20 +36,33 @@ public class PlaceholdersRegister extends PlaceholderExpansion {
 
     @Override
     public String onRequest(OfflinePlayer player, String paramString) {
-        String[] params  = paramString.split("_");
+        String[] params  = paramString.split("_", -1);
         Account  account = eco.player(player.getUniqueId());
 
         if (params[0].equalsIgnoreCase("balance") || params[0].equalsIgnoreCase("money")) {
 
-            if (params.length == 2) {
-                if (params[1].equalsIgnoreCase("vault")) {
-                    return String.valueOf(account.vaultBalance());
-                }
-                if (params[1].equalsIgnoreCase("inventory")) {
-                    return String.valueOf(account.invBalance());
-                }
-            } else if (params.length == 1) {
+            if (params.length == 1) {
                 return String.valueOf(account.balance());
+            }
+
+            String metric = params[1];
+            if (params.length == 2) {
+                return balance(account, metric);
+            }
+
+            if (params.length >= 3 && (metric.equalsIgnoreCase("player")
+                    || metric.equalsIgnoreCase("vault")
+                    || metric.equalsIgnoreCase("enderchest")
+                    || metric.equalsIgnoreCase("endervault"))) {
+                String targetName = Arrays.stream(params, 2, params.length)
+                        .collect(Collectors.joining("_"));
+                Account target = eco.getAccount(targetName);
+                if (!target.exists()) {
+                    return null;
+                }
+                return metric.equalsIgnoreCase("player")
+                        ? String.valueOf(target.balance())
+                        : balance(target, metric);
             }
         } else if (params[0].equalsIgnoreCase("vault") && params.length >= 2) {
 
@@ -83,5 +99,21 @@ public class PlaceholdersRegister extends PlaceholderExpansion {
         }
 
         return null; // Placeholder is unknown by the Expansion
+    }
+
+    private String balance(Account account, String metric) {
+        if (metric.equalsIgnoreCase("vault")) {
+            return String.valueOf(account.vaultBalance());
+        }
+        if (metric.equalsIgnoreCase("inventory")) {
+            return String.valueOf(account.invBalance());
+        }
+        if (metric.equalsIgnoreCase("enderchest")) {
+            return String.valueOf(account.endBalance());
+        }
+        if (metric.equalsIgnoreCase("endervault")) {
+            return String.valueOf(account.vaultBalance() + account.endBalance());
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

Closes #90. Extend the existing PlaceholderAPI expansion with the remaining account balance variants requested by the issue.

## Changes

- Add named-player total balance lookup.
- Add named-player vault, ender-chest, and endervault lookups.
- Add current-player ender-chest and endervault lookups.
- Preserve unknown-target `null` semantics and underscore-containing names.
- Leave WorldGuard and top-10 balance requests out of scope.

## Tests

- `mvn -B test -q`
- `mvn -B package -q`
- `git diff --check`

The Maven build completes successfully; EBean enhancement prints existing Java 24 class-file compatibility warnings.