### PR TITLE
Decouple pending operations from Ebean access

### DIFF
--- a/src/main/java/org/gestern/gringotts/data/DAO.java
+++ b/src/main/java/org/gestern/gringotts/data/DAO.java
@@ -6,6 +6,7 @@ import org.gestern.gringotts.GringottsStorageException;
 import org.gestern.gringotts.accountholder.AccountHolder;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The interface Dao.
@@ -164,6 +165,27 @@ public interface DAO {
      * @return boolean indicating success or failure
      */
     boolean deleteAccountChest(String world, int x, int y, int z);
+
+    /**
+     * Return all deferred chest operations persisted by the plugin.
+     *
+     * @return persisted pending operations
+     */
+    List<EBeanPendingOperation> retrievePendingOperations();
+
+    /**
+     * Persist a deferred chest operation.
+     *
+     * @param operation operation to persist
+     */
+    void storePendingOperation(EBeanPendingOperation operation);
+
+    /**
+     * Delete a deferred chest operation.
+     *
+     * @param operation operation to delete
+     */
+    void deletePendingOperation(EBeanPendingOperation operation);
 
     /**
      * Shutdown the database connection.

--- a/src/main/java/org/gestern/gringotts/data/EBeanDAO.java
+++ b/src/main/java/org/gestern/gringotts/data/EBeanDAO.java
@@ -474,4 +474,19 @@ public class EBeanDAO implements DAO {
         updateChest.setParameter("total_value", balance);
         return updateChest.execute() > 0;
     }
+
+    @Override
+    public synchronized List<EBeanPendingOperation> retrievePendingOperations() {
+        return db.find(EBeanPendingOperation.class).findList();
+    }
+
+    @Override
+    public synchronized void storePendingOperation(EBeanPendingOperation operation) {
+        db.save(operation);
+    }
+
+    @Override
+    public synchronized void deletePendingOperation(EBeanPendingOperation operation) {
+        db.delete(operation);
+    }
 }

--- a/src/main/java/org/gestern/gringotts/pendingoperation/PendingOperationManager.java
+++ b/src/main/java/org/gestern/gringotts/pendingoperation/PendingOperationManager.java
@@ -15,7 +15,7 @@ public class PendingOperationManager {
 
 
     public void init() {
-        this.pendingOperations = Gringotts.instance.getDatabase().find(EBeanPendingOperation.class).findList();
+        this.pendingOperations = Gringotts.instance.getDao().retrievePendingOperations();
         this.ready = true;
     }
 
@@ -45,13 +45,13 @@ public class PendingOperationManager {
             }
 
             pendingOperations.remove(operation);
-            Gringotts.instance.getDatabase().delete(operation);
+            Gringotts.instance.getDao().deletePendingOperation(operation);
         }
 
     }
 
     public void registerNewOperation(EBeanPendingOperation op) {
-        Gringotts.instance.getDatabase().save(op);
+        Gringotts.instance.getDao().storePendingOperation(op);
         pendingOperations.add(op);
     }
 


### PR DESCRIPTION
## Summary

Part 1 of #108. Route pending-operation persistence through the existing `DAO` boundary so the pending-operation manager no longer depends directly on Ebean. This isolates one of the remaining Ebean consumers before replacing the persistence implementation.

This PR intentionally does not remove Ebean yet; the DAO/model replacement and SQLite migration compatibility remain follow-up work on #108.

## Changes

- Add pending-operation persistence methods to `DAO`.
- Implement those methods in `EBeanDAO`.
- Update `PendingOperationManager` to use `DAO` for load/save/delete.

## Tests

- [x] `git diff --check`
- [x] `mvn -B test -q`
- [x] `mvn -B package -q`

## Checklist

- [x] Linked branch for #108
- [x] No direct pending-operation database calls remain outside the DAO
- [ ] Full Ebean replacement and migration compatibility (remaining scope of #108)